### PR TITLE
Feature/3d focus

### DIFF
--- a/CODE/IconCollection.cs
+++ b/CODE/IconCollection.cs
@@ -9,11 +9,13 @@ public partial class IconCollection : Node
     private int _lastFilledCol;
     private int _lastFilledRow;
     private Array<VBoxContainer> _allIcons;
+    private PortView3D _portView3D;
 
     public override void _Ready()
     {
         row = 0;
         col = 0;
+        _portView3D = GetNode<PortView3D>("../RightPanel/SubViewportContainer/SubViewport/3dView");
         _allIcons = Variant.From(GetNode("HBoxContainer").GetChildren()).AsGodotArray<VBoxContainer>();
 
         var artDetailsMasterList = FileAccess.Open("res://ART/Your Art Here/Master List.csv", FileAccess.ModeFlags.Read);
@@ -31,6 +33,7 @@ public partial class IconCollection : Node
 
             columnToAddTo %= _allIcons.Count;
             artDetails = artDetailsMasterList.GetCsvLine();
+            break;
         } while (artDetailsMasterList.EofReached() == false);
 
         if (columnToAddTo == 0)
@@ -44,7 +47,7 @@ public partial class IconCollection : Node
         (_allIcons[0].GetChildren()[0] as ArtIcon).Highlight();
     }
 
-    public override void _Process(double delta)
+    public void _Control(double delta)
     {
         if (Input.IsActionJustPressed("Up"))
             Up();
@@ -63,6 +66,12 @@ public partial class IconCollection : Node
 
         if (Input.IsActionJustPressed("RotateCounterClockwise"))
             (_allIcons[col].GetChildren()[row] as ArtIcon).RotateCounterClockwise();
+
+        if (Input.IsActionJustPressed("RotateClockwise3D"))
+            _portView3D.RotateClockwise();
+
+        if (Input.IsActionJustPressed("RotateCounterClockwise3D"))
+            _portView3D.RotateCounterClockwise();
     }
 
     public ArtIcon FocusedArtIcon()

--- a/CODE/IconCollection.cs
+++ b/CODE/IconCollection.cs
@@ -33,7 +33,6 @@ public partial class IconCollection : Node
 
             columnToAddTo %= _allIcons.Count;
             artDetails = artDetailsMasterList.GetCsvLine();
-            break;
         } while (artDetailsMasterList.EofReached() == false);
 
         if (columnToAddTo == 0)

--- a/CODE/RightPanel.cs
+++ b/CODE/RightPanel.cs
@@ -1,5 +1,4 @@
 using Godot;
-using System;
 
 public partial class RightPanel : Node2D
 {
@@ -18,10 +17,6 @@ public partial class RightPanel : Node2D
 
         _animationPlayer = GetNode<AnimationPlayer>("SubViewportContainer/AnimationPlayer");
         _animationPlayer.Stop();
-    }
-
-    public override void _Process(double delta)
-    {
     }
 
     public void Focus3DView()

--- a/CODE/RootWindow.cs
+++ b/CODE/RootWindow.cs
@@ -34,6 +34,11 @@ public partial class RootWindow : Node2D
             {
                 _rightPanel.Focus3DView();
             }
+
+            if (Input.IsActionJustPressed("East RightThumb"))
+            {
+                _rightPanel.UnFocus3DView();
+            }
         }
         else if (_state == State.Details)
         {

--- a/CODE/RootWindow.cs
+++ b/CODE/RootWindow.cs
@@ -30,18 +30,19 @@ public partial class RootWindow : Node2D
         {
             _iconCollection._Control(delta);
 
-            if (Input.IsActionJustPressed("South RightThumb"))
+            if (Input.IsActionJustPressed("South RightThumb") && _rightPanel.Busy() == false)
             {
                 _rightPanel.Focus3DView();
+                _state = State.Details;
             }
-
+        }
+        else if (_state == State.Details && _rightPanel.Busy() == false)
+        {
             if (Input.IsActionJustPressed("East RightThumb"))
             {
                 _rightPanel.UnFocus3DView();
+                _state = State.Icon;
             }
-        }
-        else if (_state == State.Details)
-        {
         }
     }
 }

--- a/CODE/RootWindow.cs
+++ b/CODE/RootWindow.cs
@@ -33,10 +33,10 @@ public partial class RootWindow : Node2D
             if (Input.IsActionJustPressed("South RightThumb") && _rightPanel.Busy() == false)
             {
                 _rightPanel.Focus3DView();
-                _state = State.Details;
+                _state = State.ArtFocused;
             }
         }
-        else if (_state == State.Details && _rightPanel.Busy() == false)
+        else if (_state == State.ArtFocused && _rightPanel.Busy() == false)
         {
             if (Input.IsActionJustPressed("East RightThumb"))
             {

--- a/CODE/RootWindow.cs
+++ b/CODE/RootWindow.cs
@@ -4,31 +4,39 @@ using System;
 public partial class RootWindow : Node2D
 {
     private IconCollection _iconCollection;
-    private PortView3D _portView3D;
+    private RightPanel _rightPanel;
 
-    private RichTextLabel _artTitle;
-    private RichTextLabel _artId;
+    private enum State
+    {
+        Icon,
+        Details,
+        ArtFocused
+    };
+
+    private State _state;
 
     public override void _Ready()
     {
         _iconCollection = GetNode<IconCollection>("IconCollection");
-        _portView3D = GetNode<PortView3D>("SubViewportContainer/SubViewport/3dView");
-        _artTitle = GetNode<RichTextLabel>("ArtTitle/RichTextLabel");
-        _artId = GetNode<RichTextLabel>("ArtId/Control/ID Number");
+        _rightPanel = GetNode<RightPanel>("RightPanel");
+        _state = State.Icon;
     }
 
     public override void _Process(double delta)
     {
-        ArtIcon currentFocus = _iconCollection.FocusedArtIcon();
+        _rightPanel.SetFocusedArt(_iconCollection.FocusedArtIcon());
 
-        _portView3D.ChangeArt(currentFocus.ArtTexture());
-        _artTitle.Text = currentFocus._title;
-        _artId.Text = currentFocus._id;
+        if (_state == State.Icon)
+        {
+            _iconCollection._Control(delta);
 
-        if (Input.IsActionJustPressed("RotateClockwise3D"))
-            _portView3D.RotateClockwise();
-
-        if (Input.IsActionJustPressed("RotateCounterClockwise3D"))
-            _portView3D.RotateCounterClockwise();
+            if (Input.IsActionJustPressed("South RightThumb"))
+            {
+                _rightPanel.Focus3DView();
+            }
+        }
+        else if (_state == State.Details)
+        {
+        }
     }
 }

--- a/Root.tscn
+++ b/Root.tscn
@@ -1,11 +1,8 @@
-[gd_scene load_steps=7 format=3 uid="uid://y7128kiewxq1"]
+[gd_scene load_steps=4 format=3 uid="uid://y7128kiewxq1"]
 
 [ext_resource type="PackedScene" uid="uid://m37vxohbdie7" path="res://SCENES/IconCollection.tscn" id="1_c53fi"]
 [ext_resource type="Script" path="res://CODE/RootWindow.cs" id="1_ymshw"]
-[ext_resource type="PackedScene" uid="uid://bun4786lcjrqy" path="res://SCENES/UI/ArtTitle.tscn" id="2_15dh6"]
-[ext_resource type="PackedScene" uid="uid://c34d7twrflrjj" path="res://SCENES/UI/ArtID.tscn" id="3_gg4vn"]
-[ext_resource type="PackedScene" uid="uid://cff7akcio5o7" path="res://SCENES/StarRating.tscn" id="4_3i65a"]
-[ext_resource type="PackedScene" uid="uid://d2w26aw448b0e" path="res://SCENES/3DView.tscn" id="7_0eqy0"]
+[ext_resource type="PackedScene" uid="uid://mo02sw5hpvph" path="res://SCENES/RightPanel.tscn" id="3_lpm3e"]
 
 [node name="RootWindow" type="Node2D"]
 script = ExtResource("1_ymshw")
@@ -32,25 +29,4 @@ color = Color(0.663665, 0.306272, 0.51105, 0.533333)
 position = Vector2(-553, -301)
 scale = Vector2(2, 2)
 
-[node name="ArtTitle" parent="." instance=ExtResource("2_15dh6")]
-position = Vector2(-86, -304)
-
-[node name="ArtId" parent="." instance=ExtResource("3_gg4vn")]
-position = Vector2(172, -283)
-
-[node name="StarRating" parent="." instance=ExtResource("4_3i65a")]
-position = Vector2(368, -286)
-
-[node name="SubViewportContainer" type="SubViewportContainer" parent="."]
-offset_left = -80.0
-offset_top = -170.0
-offset_right = 1840.0
-offset_bottom = 910.0
-scale = Vector2(0.3, 0.3)
-
-[node name="SubViewport" type="SubViewport" parent="SubViewportContainer"]
-handle_input_locally = false
-size = Vector2i(1920, 1080)
-render_target_update_mode = 4
-
-[node name="3dView" parent="SubViewportContainer/SubViewport" instance=ExtResource("7_0eqy0")]
+[node name="RightPanel" parent="." instance=ExtResource("3_lpm3e")]

--- a/Root.tscn
+++ b/Root.tscn
@@ -30,3 +30,5 @@ position = Vector2(-553, -301)
 scale = Vector2(2, 2)
 
 [node name="RightPanel" parent="." instance=ExtResource("3_lpm3e")]
+position = Vector2(-114, -299)
+scale = Vector2(1, 0.857)

--- a/SCENES/RightPanel.cs
+++ b/SCENES/RightPanel.cs
@@ -1,0 +1,37 @@
+using Godot;
+using System;
+
+public partial class RightPanel : Node2D
+{
+    private PortView3D _portView3D;
+
+    private RichTextLabel _artTitle;
+    private RichTextLabel _artId;
+
+    private AnimationPlayer _animationPlayer;
+
+    public override void _Ready()
+    {
+        _portView3D = GetNode<PortView3D>("SubViewportContainer/SubViewport/3dView");
+        _artTitle = GetNode<RichTextLabel>("ArtTitle/RichTextLabel");
+        _artId = GetNode<RichTextLabel>("ArtId/Control/ID Number");
+
+        _animationPlayer = GetNode<AnimationPlayer>("SubViewportContainer/AnimationPlayer");
+    }
+
+    public override void _Process(double delta)
+    {
+    }
+
+    public void Focus3DView()
+    {
+        _animationPlayer.Play("Grow");
+    }
+
+    public void SetFocusedArt(ArtIcon currentFocus)
+    {
+        _portView3D.ChangeArt(currentFocus.ArtTexture());
+        _artTitle.Text = currentFocus._title;
+        _artId.Text = currentFocus._id;
+    }
+}

--- a/SCENES/RightPanel.cs
+++ b/SCENES/RightPanel.cs
@@ -17,6 +17,7 @@ public partial class RightPanel : Node2D
         _artId = GetNode<RichTextLabel>("ArtId/Control/ID Number");
 
         _animationPlayer = GetNode<AnimationPlayer>("SubViewportContainer/AnimationPlayer");
+        _animationPlayer.Stop();
     }
 
     public override void _Process(double delta)
@@ -26,6 +27,11 @@ public partial class RightPanel : Node2D
     public void Focus3DView()
     {
         _animationPlayer.Play("Grow");
+    }
+
+    public void UnFocus3DView()
+    {
+        _animationPlayer.Play("Shrink");
     }
 
     public void SetFocusedArt(ArtIcon currentFocus)

--- a/SCENES/RightPanel.cs
+++ b/SCENES/RightPanel.cs
@@ -34,6 +34,11 @@ public partial class RightPanel : Node2D
         _animationPlayer.Play("Shrink");
     }
 
+    public bool Busy()
+    {
+        return _animationPlayer.IsPlaying();
+    }
+
     public void SetFocusedArt(ArtIcon currentFocus)
     {
         _portView3D.ChangeArt(currentFocus.ArtTexture());

--- a/SCENES/RightPanel.tscn
+++ b/SCENES/RightPanel.tscn
@@ -1,6 +1,6 @@
 [gd_scene load_steps=10 format=3 uid="uid://mo02sw5hpvph"]
 
-[ext_resource type="Script" path="res://SCENES/RightPanel.cs" id="1_6iyby"]
+[ext_resource type="Script" path="res://CODE/RightPanel.cs" id="1_6iyby"]
 [ext_resource type="PackedScene" uid="uid://bun4786lcjrqy" path="res://SCENES/UI/ArtTitle.tscn" id="1_qjsnb"]
 [ext_resource type="PackedScene" uid="uid://c34d7twrflrjj" path="res://SCENES/UI/ArtID.tscn" id="2_o2h0e"]
 [ext_resource type="PackedScene" uid="uid://cff7akcio5o7" path="res://SCENES/StarRating.tscn" id="3_p7cer"]
@@ -33,6 +33,9 @@ tracks/1/keys = {
 "values": [Vector2(-630, -280), Vector2(-820, -200)]
 }
 
+[sub_resource type="Animation" id="Animation_cglci"]
+length = 0.001
+
 [sub_resource type="Animation" id="Animation_cadxy"]
 resource_name = "Shrink"
 tracks/0/type = "value"
@@ -59,9 +62,6 @@ tracks/1/keys = {
 "update": 0,
 "values": [Vector2(-820, -200), Vector2(-630, -280)]
 }
-
-[sub_resource type="Animation" id="Animation_cglci"]
-length = 0.001
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_w7lco"]
 _data = {

--- a/SCENES/RightPanel.tscn
+++ b/SCENES/RightPanel.tscn
@@ -1,0 +1,70 @@
+[gd_scene load_steps=8 format=3 uid="uid://mo02sw5hpvph"]
+
+[ext_resource type="Script" path="res://SCENES/RightPanel.cs" id="1_6iyby"]
+[ext_resource type="PackedScene" uid="uid://bun4786lcjrqy" path="res://SCENES/UI/ArtTitle.tscn" id="1_qjsnb"]
+[ext_resource type="PackedScene" uid="uid://c34d7twrflrjj" path="res://SCENES/UI/ArtID.tscn" id="2_o2h0e"]
+[ext_resource type="PackedScene" uid="uid://cff7akcio5o7" path="res://SCENES/StarRating.tscn" id="3_p7cer"]
+[ext_resource type="PackedScene" uid="uid://d2w26aw448b0e" path="res://SCENES/3DView.tscn" id="4_uvx0u"]
+
+[sub_resource type="Animation" id="Animation_6f1xb"]
+resource_name = "Grow"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(0.3, 0.3), Vector2(0.65, 0.65)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(-80, -200), Vector2(-630, -350)]
+}
+
+[sub_resource type="AnimationLibrary" id="AnimationLibrary_w7lco"]
+_data = {
+"Grow": SubResource("Animation_6f1xb")
+}
+
+[node name="RightPanel" type="Node2D"]
+script = ExtResource("1_6iyby")
+
+[node name="ArtTitle" parent="." instance=ExtResource("1_qjsnb")]
+position = Vector2(-86, -304)
+
+[node name="ArtId" parent="." instance=ExtResource("2_o2h0e")]
+position = Vector2(172, -283)
+
+[node name="StarRating" parent="." instance=ExtResource("3_p7cer")]
+position = Vector2(368, -286)
+
+[node name="SubViewportContainer" type="SubViewportContainer" parent="."]
+offset_left = -480.0
+offset_top = -320.0
+offset_right = 1440.0
+offset_bottom = 760.0
+scale = Vector2(0.65, 0.65)
+
+[node name="SubViewport" type="SubViewport" parent="SubViewportContainer"]
+handle_input_locally = false
+size = Vector2i(1920, 1080)
+render_target_update_mode = 4
+
+[node name="3dView" parent="SubViewportContainer/SubViewport" instance=ExtResource("4_uvx0u")]
+
+[node name="AnimationPlayer" type="AnimationPlayer" parent="SubViewportContainer"]
+libraries = {
+"": SubResource("AnimationLibrary_w7lco")
+}

--- a/SCENES/RightPanel.tscn
+++ b/SCENES/RightPanel.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://mo02sw5hpvph"]
+[gd_scene load_steps=10 format=3 uid="uid://mo02sw5hpvph"]
 
 [ext_resource type="Script" path="res://SCENES/RightPanel.cs" id="1_6iyby"]
 [ext_resource type="PackedScene" uid="uid://bun4786lcjrqy" path="res://SCENES/UI/ArtTitle.tscn" id="1_qjsnb"]
@@ -15,10 +15,10 @@ tracks/0/path = NodePath(".:scale")
 tracks/0/interp = 1
 tracks/0/loop_wrap = true
 tracks/0/keys = {
-"times": PackedFloat32Array(0, 1),
-"transitions": PackedFloat32Array(1, 1),
+"times": PackedFloat32Array(0, 0.1, 1),
+"transitions": PackedFloat32Array(1, 1, 1),
 "update": 0,
-"values": [Vector2(0.3, 0.3), Vector2(0.65, 0.65)]
+"values": [Vector2(0.3, 0.3), Vector2(0.27, 0.27), Vector2(0.74, 0.74)]
 }
 tracks/1/type = "value"
 tracks/1/imported = false
@@ -30,32 +30,65 @@ tracks/1/keys = {
 "times": PackedFloat32Array(0, 1),
 "transitions": PackedFloat32Array(1, 1),
 "update": 0,
-"values": [Vector2(-80, -200), Vector2(-630, -350)]
+"values": [Vector2(-630, -280), Vector2(-820, -200)]
 }
+
+[sub_resource type="Animation" id="Animation_cadxy"]
+resource_name = "Shrink"
+tracks/0/type = "value"
+tracks/0/imported = false
+tracks/0/enabled = true
+tracks/0/path = NodePath(".:scale")
+tracks/0/interp = 1
+tracks/0/loop_wrap = true
+tracks/0/keys = {
+"times": PackedFloat32Array(0, 0.1, 1),
+"transitions": PackedFloat32Array(1, 1, 1),
+"update": 0,
+"values": [Vector2(0.74, 0.74), Vector2(0.7, 0.7), Vector2(0.3, 0.3)]
+}
+tracks/1/type = "value"
+tracks/1/imported = false
+tracks/1/enabled = true
+tracks/1/path = NodePath(".:position")
+tracks/1/interp = 1
+tracks/1/loop_wrap = true
+tracks/1/keys = {
+"times": PackedFloat32Array(0, 1),
+"transitions": PackedFloat32Array(1, 1),
+"update": 0,
+"values": [Vector2(-820, -200), Vector2(-630, -280)]
+}
+
+[sub_resource type="Animation" id="Animation_cglci"]
+length = 0.001
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_w7lco"]
 _data = {
-"Grow": SubResource("Animation_6f1xb")
+"Grow": SubResource("Animation_6f1xb"),
+"RESET": SubResource("Animation_cglci"),
+"Shrink": SubResource("Animation_cadxy")
 }
 
 [node name="RightPanel" type="Node2D"]
+scale = Vector2(1.167, 1)
 script = ExtResource("1_6iyby")
 
 [node name="ArtTitle" parent="." instance=ExtResource("1_qjsnb")]
-position = Vector2(-86, -304)
 
 [node name="ArtId" parent="." instance=ExtResource("2_o2h0e")]
-position = Vector2(172, -283)
+position = Vector2(277, 20)
 
 [node name="StarRating" parent="." instance=ExtResource("3_p7cer")]
-position = Vector2(368, -286)
+position = Vector2(509, 21)
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="."]
-offset_left = -480.0
-offset_top = -320.0
-offset_right = 1440.0
-offset_bottom = 760.0
-scale = Vector2(0.65, 0.65)
+offset_left = -820.0
+offset_top = -200.0
+offset_right = 1100.0
+offset_bottom = 880.0
+scale = Vector2(0.74, 0.74)
+pivot_offset = Vector2(960, 540)
 
 [node name="SubViewport" type="SubViewport" parent="SubViewportContainer"]
 handle_input_locally = false
@@ -68,3 +101,10 @@ render_target_update_mode = 4
 libraries = {
 "": SubResource("AnimationLibrary_w7lco")
 }
+
+[node name="ReferenceRect" type="ReferenceRect" parent="."]
+offset_left = -460.0
+offset_top = -30.0
+offset_right = -420.0
+offset_bottom = 17.165
+scale = Vector2(29.2, 16.24)

--- a/SCENES/RightPanel.tscn
+++ b/SCENES/RightPanel.tscn
@@ -83,11 +83,11 @@ position = Vector2(277, 20)
 position = Vector2(509, 21)
 
 [node name="SubViewportContainer" type="SubViewportContainer" parent="."]
-offset_left = -820.0
-offset_top = -200.0
-offset_right = 1100.0
-offset_bottom = 880.0
-scale = Vector2(0.74, 0.74)
+offset_left = -630.0
+offset_top = -280.0
+offset_right = 1290.0
+offset_bottom = 800.0
+scale = Vector2(0.3, 0.3)
 pivot_offset = Vector2(960, 540)
 
 [node name="SubViewport" type="SubViewport" parent="SubViewportContainer"]

--- a/project.godot
+++ b/project.godot
@@ -15,6 +15,11 @@ run/main_scene="res://Root.tscn"
 config/features=PackedStringArray("4.2", "C#", "Forward Plus")
 config/icon="res://icon.svg"
 
+[display]
+
+window/stretch/mode="viewport"
+window/stretch/aspect="expand"
+
 [dotnet]
 
 project/assembly_name="Artlopedia"
@@ -71,5 +76,11 @@ RotateCounterClockwise3D={
 "deadzone": 0.5,
 "events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":90,"key_label":0,"unicode":122,"echo":false,"script":null)
 , Object(InputEventJoypadMotion,"resource_local_to_scene":false,"resource_name":"","device":-1,"axis":4,"axis_value":1.0,"script":null)
+]
+}
+"South RightThumb"={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":0,"pressure":0.0,"pressed":true,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
 ]
 }

--- a/project.godot
+++ b/project.godot
@@ -84,3 +84,9 @@ RotateCounterClockwise3D={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":32,"key_label":0,"unicode":32,"echo":false,"script":null)
 ]
 }
+"East RightThumb"={
+"deadzone": 0.5,
+"events": [Object(InputEventJoypadButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"button_index":1,"pressure":0.0,"pressed":true,"script":null)
+, Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194308,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}


### PR DESCRIPTION
## 3D Focus
User can now have artpiece take up entire screen. User can switch back and forth between the two views.

## Type of Change
- [X] New feature (non-breaking change which adds functionality)

## Description of the Feature
Just like in the piklopedia, I want to be able to make the 3D viewport the main focus.
![Camera Focus](https://github.com/user-attachments/assets/518affff-c750-41ef-90c5-0ed06b5e8b34)

Here's the result so far (smoothness and speed is a little off cause its a small gif):
![Camera Focus](https://github.com/user-attachments/assets/8cf27888-48f4-4fb4-933a-2489be9e1942)

## Implementation Details
I've switched over to managing the input based on the current state of the application. So right now the player could be in the "Icon" state where the dpad will move the cursor over each art piece icon. And when they select a piece it switches to the "ArtFocused" state where the only option is to go back to an icon state. In later work I will be including a "Detail" state which will be when the player can select things like tags, names, ratings, etc

## Impact of the Feature
Looks damn good 😎 

## Additional Remarks
Animation will likely change in the future. Feels a liiiiittle slow on the expansion so might speed it up.
