### PR TITLE
Feature/art config http request

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -406,3 +406,4 @@ FodyWeavers.xsd
 *.sln.iml
 /Properties
 /DOCUMENTATION
+CODE/config.json

--- a/CODE/ArtIcon.cs
+++ b/CODE/ArtIcon.cs
@@ -14,8 +14,8 @@ public partial class ArtIcon : Control
     public string _id;
     public string _title;
     public short _rating;
-    public String[] _tags;
-    public String _locationPurchased;
+    public string[] _tags;
+    public string _locationPurchased;
     public float _width;
     public float _height;
     public float _orientation2D;

--- a/CODE/ArtIcon.cs
+++ b/CODE/ArtIcon.cs
@@ -51,12 +51,12 @@ public partial class ArtIcon : Control
 
     public void RotateClockwise()
     {
-        (GetNode("AspectRatioContainer") as AspectRatioContainer).RotationDegrees += 90;
+        _container.RotationDegrees += 90;
     }
 
     public void RotateCounterClockwise()
     {
-        (GetNode("AspectRatioContainer") as AspectRatioContainer).RotationDegrees -= 90;
+        _container.RotationDegrees -= 90;
     }
 
     public void Highlight()
@@ -69,14 +69,31 @@ public partial class ArtIcon : Control
         _background.Texture = _normal;
     }
 
-    public Dictionary ToJson()
+    public void Deserialize(Dictionary artDetails)
+    {
+        _height = (float)artDetails["dimensions"].AsGodotDictionary()["height"];
+        _width = (float)artDetails["dimensions"].AsGodotDictionary()["width"];
+
+        _orientation2D = (float)artDetails["orientation"].AsGodotDictionary()["2D"];
+        _orientation3D = (float)artDetails["orientation"].AsGodotDictionary()["3D"];
+
+        _container.RotationDegrees = _orientation2D;
+
+        _id = artDetails["id"].AsString();
+        _locationPurchased = artDetails["locationPurchased"].AsString();
+        _rating = (short)artDetails["rating"];
+        _tags = artDetails["tags"].AsStringArray();
+        _title = artDetails["title"].AsString();
+    }
+
+    public Dictionary Serialize()
     {
         Dictionary output = new Dictionary();
         Dictionary dimensions = new Dictionary();
         dimensions.Add("width", _width);
         dimensions.Add("height", _height);
         Dictionary orientation = new Dictionary();
-        orientation.Add("2D", (GetNode("AspectRatioContainer") as AspectRatioContainer).RotationDegrees);
+        orientation.Add("2D", _container.RotationDegrees);
         orientation.Add("3D", _orientation3D);
 
         output.Add("title", _title);

--- a/CODE/ArtIcon.cs
+++ b/CODE/ArtIcon.cs
@@ -1,4 +1,5 @@
 using Godot;
+using Godot.Collections;
 using System;
 
 public partial class ArtIcon : Control
@@ -12,6 +13,13 @@ public partial class ArtIcon : Control
 
     public string _id;
     public string _title;
+    public short _rating;
+    public String[] _tags;
+    public String _locationPurchased;
+    public float _width;
+    public float _height;
+    public float _orientation2D;
+    public float _orientation3D;
 
     public override void _Ready()
     {
@@ -59,5 +67,26 @@ public partial class ArtIcon : Control
     public void UnHighlight()
     {
         _background.Texture = _normal;
+    }
+
+    public Dictionary ToJson()
+    {
+        Dictionary output = new Dictionary();
+        Dictionary dimensions = new Dictionary();
+        dimensions.Add("width", _width);
+        dimensions.Add("height", _height);
+        Dictionary orientation = new Dictionary();
+        orientation.Add("2D", (GetNode("AspectRatioContainer") as AspectRatioContainer).RotationDegrees);
+        orientation.Add("3D", _orientation3D);
+
+        output.Add("title", _title);
+        output.Add("id", _id);
+        output.Add("rating", _rating);
+        output.Add("tags", _tags);
+        output.Add("locationPurchased", _locationPurchased);
+        output.Add("dimensions", dimensions);
+        output.Add("orientation", orientation);
+
+        return output;
     }
 }

--- a/CODE/HttpRequestHandler.cs
+++ b/CODE/HttpRequestHandler.cs
@@ -1,0 +1,56 @@
+using Godot;
+using Godot.Collections;
+using System;
+using System.Collections.Generic;
+
+public partial class HttpRequestHandler : Node
+{
+    private static HttpRequest _requester;
+    private String _baseUrl;
+
+    [Export]
+    private bool _debugState;
+
+    public override void _Ready()
+    {
+        _requester = new HttpRequest();
+        AddChild(_requester);
+        _requester.RequestCompleted += HttpRequestCompleted;
+
+        var configContent = FileAccess.GetFileAsString("res://CODE/config.json");
+        var config = Json.ParseString(configContent).AsGodotDictionary();
+        _baseUrl = config.GetValueOrDefault("baseUrl", "").AsString();
+    }
+
+    public void GET()
+    {
+        Error error = _requester.Request(String.Format("{0}/art", _baseUrl), null, HttpClient.Method.Get);
+
+        if (error != Error.Ok && _debugState)
+        {
+            GD.PushError(String.Format("Failure in HttpRequestHandler.GET\n\t{0}", error.ToString()));
+        }
+    }
+
+    public void PUT(Array<Dictionary> allArt)
+    {
+        Dictionary request = new Dictionary();
+        request.Add("items", allArt);
+
+        Error error = _requester.Request(String.Format("{0}/art", _baseUrl), null, HttpClient.Method.Put, Json.Stringify(request, "\t"));
+
+        if (error != Error.Ok && _debugState)
+        {
+            GD.PushError(String.Format("Failure in HttpRequestHandler.PUT\n\t{0}", error.ToString()));
+        }
+    }
+
+    // Called when the HTTP request is completed.
+    private void HttpRequestCompleted(long result, long responseCode, string[] headers, byte[] body)
+    {
+        if (responseCode != 200 && _debugState)
+            GD.PushError(String.Format("Request failed: {0} \n{1}", responseCode, Json.ParseString(body.GetStringFromUtf8())));
+        else if (_debugState)
+            GD.PushWarning(String.Format("Request Success: {0} \n{1}", responseCode, Json.ParseString(body.GetStringFromUtf8())));
+    }
+}

--- a/CODE/HttpRequestHandler.cs
+++ b/CODE/HttpRequestHandler.cs
@@ -69,6 +69,6 @@ public partial class HttpRequestHandler : HttpRequest
         if (responseCode != 200)
             GD.PushError(String.Format("Request failed: {0} \n{1}", responseCode, Json.ParseString(body.GetStringFromUtf8())));
         else
-            GD.PushWarning(String.Format("Request Success: {0} \n{1}", responseCode, Json.ParseString(body.GetStringFromUtf8())));
+            GD.PushWarning(String.Format("Request Success: {0} \n{1}", responseCode, Json.ParseString(body.GetStringFromUtf8()).AsGodotDictionary()));
     }
 }

--- a/CODE/IconCollection.cs
+++ b/CODE/IconCollection.cs
@@ -78,6 +78,23 @@ public partial class IconCollection : Node
         return _allIcons[col].GetChildren()[row] as ArtIcon;
     }
 
+    public Array<ArtIcon> AllArt()
+    {
+        Array<ArtIcon> allArt = new Array<ArtIcon>();
+        foreach (var column in _allIcons)
+        {
+            var columnArt = column.GetChildren();
+
+            foreach (var art in columnArt)
+            {
+                if (art is ArtIcon)
+                    allArt.Add(art as ArtIcon);
+            }
+        }
+
+        return allArt;
+    }
+
     public void Down()
     {
         (_allIcons[col].GetChildren()[row] as ArtIcon).UnHighlight();

--- a/CODE/IconCollection.cs
+++ b/CODE/IconCollection.cs
@@ -78,6 +78,22 @@ public partial class IconCollection : Node
         return _allIcons[col].GetChildren()[row] as ArtIcon;
     }
 
+    public void AllArt(Dictionary<string, Dictionary> allArt)
+    {
+        foreach (var column in _allIcons)
+        {
+            var columnArt = column.GetChildren();
+
+            foreach (var art in columnArt)
+            {
+                if (art is ArtIcon)
+                {
+                    (art as ArtIcon).Deserialize(allArt[(art as ArtIcon)._id]);
+                }
+            }
+        }
+    }
+
     public Array<ArtIcon> AllArt()
     {
         Array<ArtIcon> allArt = new Array<ArtIcon>();

--- a/CODE/IconCollection.cs
+++ b/CODE/IconCollection.cs
@@ -78,7 +78,7 @@ public partial class IconCollection : Node
         return _allIcons[col].GetChildren()[row] as ArtIcon;
     }
 
-    public void AllArt(Dictionary<string, Dictionary> allArt)
+    public void AllArt(Dictionary<string, Dictionary> allArtDetails)
     {
         foreach (var column in _allIcons)
         {
@@ -88,7 +88,7 @@ public partial class IconCollection : Node
             {
                 if (art is ArtIcon)
                 {
-                    (art as ArtIcon).Deserialize(allArt[(art as ArtIcon)._id]);
+                    (art as ArtIcon).Deserialize(allArtDetails[(art as ArtIcon)._id]);
                 }
             }
         }

--- a/CODE/RootWindow.cs
+++ b/CODE/RootWindow.cs
@@ -1,10 +1,12 @@
 using Godot;
+using Godot.Collections;
 using System;
 
 public partial class RootWindow : Node2D
 {
     private IconCollection _iconCollection;
     private RightPanel _rightPanel;
+    private HttpRequestHandler _httpRequestHandler;
 
     private enum State
     {
@@ -19,6 +21,7 @@ public partial class RootWindow : Node2D
     {
         _iconCollection = GetNode<IconCollection>("IconCollection");
         _rightPanel = GetNode<RightPanel>("RightPanel");
+        _httpRequestHandler = GetNode<HttpRequestHandler>("HttpRequestHandler");
         _state = State.Icon;
     }
 
@@ -43,6 +46,22 @@ public partial class RootWindow : Node2D
                 _rightPanel.UnFocus3DView();
                 _state = State.Icon;
             }
+        }
+
+        if (Input.IsActionJustPressed("UploadArt"))
+        {
+            Array<Dictionary> requestItems = new Array<Dictionary>();
+            foreach (var art in _iconCollection.AllArt())
+            {
+                requestItems.Add(art.ToJson());
+            }
+
+            _httpRequestHandler.PUT(requestItems);
+        }
+
+        if (Input.IsActionJustPressed("DownloadArt"))
+        {
+            _httpRequestHandler.GET();
         }
     }
 }

--- a/Root.tscn
+++ b/Root.tscn
@@ -8,8 +8,9 @@
 [node name="RootWindow" type="Node2D"]
 script = ExtResource("1_ymshw")
 
-[node name="HttpRequestHandler" type="Node" parent="."]
+[node name="HttpRequestHandler" type="HTTPRequest" parent="."]
 script = ExtResource("4_jvkkl")
+_debugState = true
 
 [node name="Camera2D" type="Camera2D" parent="."]
 

--- a/Root.tscn
+++ b/Root.tscn
@@ -1,11 +1,15 @@
-[gd_scene load_steps=4 format=3 uid="uid://y7128kiewxq1"]
+[gd_scene load_steps=5 format=3 uid="uid://y7128kiewxq1"]
 
 [ext_resource type="PackedScene" uid="uid://m37vxohbdie7" path="res://SCENES/IconCollection.tscn" id="1_c53fi"]
 [ext_resource type="Script" path="res://CODE/RootWindow.cs" id="1_ymshw"]
 [ext_resource type="PackedScene" uid="uid://mo02sw5hpvph" path="res://SCENES/RightPanel.tscn" id="3_lpm3e"]
+[ext_resource type="Script" path="res://CODE/HttpRequestHandler.cs" id="4_jvkkl"]
 
 [node name="RootWindow" type="Node2D"]
 script = ExtResource("1_ymshw")
+
+[node name="HttpRequestHandler" type="Node" parent="."]
+script = ExtResource("4_jvkkl")
 
 [node name="Camera2D" type="Camera2D" parent="."]
 

--- a/SCENES/UI/ArtIcon.tscn
+++ b/SCENES/UI/ArtIcon.tscn
@@ -1,7 +1,7 @@
 [gd_scene load_steps=4 format=3 uid="uid://b45pwtrgvfes4"]
 
 [ext_resource type="Script" path="res://CODE/ArtIcon.cs" id="1_mvwlv"]
-[ext_resource type="Texture2D" uid="uid://baogn51oitkwe" path="res://ART/PRINTS DONT COMMIT/FC.JPG" id="2_uq8je"]
+[ext_resource type="Texture2D" uid="uid://baogn51oitkwe" path="res://ART/Your Art Here/FC.JPG" id="2_uq8je"]
 [ext_resource type="Texture2D" uid="uid://bqcneb1vyrrxy" path="res://ART/UI/ArtBackground.png" id="3_nru6a"]
 
 [node name="ArtPiece" type="Control"]

--- a/project.godot
+++ b/project.godot
@@ -90,3 +90,18 @@ RotateCounterClockwise3D={
 , Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194308,"key_label":0,"unicode":0,"echo":false,"script":null)
 ]
 }
+Exit={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
+UploadArt={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":49,"key_label":0,"unicode":49,"echo":false,"script":null)
+]
+}
+DownloadArt={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":50,"key_label":0,"unicode":50,"echo":false,"script":null)
+]
+}


### PR DESCRIPTION
## Saving Art Details - Remote

## Type of Change
Quality of life change / Fun experiment

## Description of the Feature
When art is loaded into the application, icons have been rotated based on the dimensions of the png, but its not always correct. Artlopedia has been able to rotate the art in the icon and on the 3D view, but havent been able to save these details. After getting a callback from a job related to AWS usesage, I decided to put together a system that could save and load the details remotely. Fun fact, first and only interview with this company so far, no one showed up. Had to call their recruiter who told me they were in a "super important meeting". At least putting this together was fun 🤷 

## Implementation Details
AWS Resources:
### S3
Created an S3 bucket called Artlopedia. Each object in this bucket is an artPieces detailed, titled with their ID. An artpieces details are formatted as such:
`
{
  "dimensions": {
    "height": 0,
    "width": 0
  },
  "id": "4A",
  "locationPurchased": "",
  "orientation": {
    "2D": 0,
    "3D": 0
  },
  "rating": 0,
  "tags": [],
  "title": "Blue Octopus"
}`

In the future I may expand on this system by creating folders that are labeled as API keys. So that theoritically each user could save their own art, under their own api key folder. api key comes in with the request, lambda uses that to get to the correct directory.

![image](https://github.com/user-attachments/assets/a248fb72-b57e-4df7-9474-6152789308ba)


### Lambda
Have a python lambda function that will take incoming requests from the API and process them. First we view the event method and path to determine if this is a PUT or GET request.
On a PUT the lambda connects to the s3Resource, grabs the Artlopedia bucket, then put's the object for each artPiece that was included in the request body. Possible improvement could be to parse the art details to ensure they are formatted correctly.

I'd say the most time consuming portion of this was learning how to work with the API method request mapping over to the integration request. The template api lambda gave me a decent enough idea on how to create a controller in the style that works with a lambda. I kept it simpler for figuring out the correct method to use, but at first I wasnt getting anything in the event parameter
![image](https://github.com/user-attachments/assets/1a7a82c8-d842-41c7-b656-70ebe192f9e5)
Then I realized I needed to turn on the mapping in the endpoint configuration.
![image](https://github.com/user-attachments/assets/9e7f1d64-fa7a-4a88-b612-c23a361d68f3)
BUT then that gave me SOOO much in the event. Just tooons of info about the request, the requester, aws stuff. I juuuust need a few items in this simple of a request. So I figured out I needed to use the scripting language for that. Found a good article and an even better example for getting just what I needed
https://medium.com/@markpgreen10/using-vtl-in-api-gateway-to-restructure-data-bc9dd6573630
![image](https://github.com/user-attachments/assets/0b2a6d76-b65f-4bd7-920d-6fa0e2b39020)

So all that took about a day to get sorted out.

### API
GET /art - retrieves all art from our S3 bucket. adds it to a list in the response body and returns
PUT /art - takes a list of art details and stores them into S3. Overwrites any details already present (as PUT's are described)

Honestly I'd like to try and learn how I can best update the documentation on aws directly. I'll post something in the wiki about it if not, at least a link to the aws documentation. So if you look and its not there and its been a bit, then uhhhh. sorry..

## Impact of the Feature
You ready for this? Result of all the work? Take note of the icons specifically
![Load from file](https://github.com/user-attachments/assets/a3f77a6c-c1ee-49ff-87c1-2fb685a8dbbe)

WOO! That is the very start of the program. We make a request to the api to GET the current details for the art.  A response is received with that data, given to the iconCollection to then go through all the icons to set the details. The main detail being the 2DRotation. Now obviously this kinda functionality doesnt warrant using 3 different AWS services, but like I said above. Wanted to practice before an interview, and AWS at this level is free to killer, why not make the data remote. Whatever I use for this should be easily interchangeable to writing to a file anyhow so this work needed to be done.

## Stability Improvements
HttpRequestHandler has debug outputs that can be toggled on and off. Been helpful for seeing how the failed request comes back.

## Additional Remarks
When I get to being able to edit entries in the program, I'll include some popups and options for saving and loading the data from aws.
